### PR TITLE
feat: handle all explicit response modes and imply one if not provided

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,28 @@ It needs to be provided either in the parameters object or as an environment var
     res.redirect(authorizationUrl);
   });
 
-  const callbackMethod = authorizeParams.response_mode === 'form_post' ? 'post' : 'get';
+  let callbackMethod;
+  let repost;
+
+  switch (authorizeParams.response_mode) {
+    case 'form_post':
+      callbackMethod = 'post';
+      break;
+    case 'query':
+      callbackMethod = 'get';
+      break;
+    case 'fragment':
+      callbackMethod = 'post';
+      repost = true;
+      break;
+    default:
+      if (/token/.test(authorizeParams.response_type)) {
+        callbackMethod = 'post';
+        repost = true;
+      } else {
+        callbackMethod = 'get';
+      }
+  }
 
   router[callbackMethod]('/callback', async (req, res) => {
     const client = await getClient();
@@ -145,7 +166,45 @@ It needs to be provided either in the parameters object or as an environment var
     res.redirect(returnTo);
   });
 
+  if (repost) {
+    router.get('/callback', async (req, res) => {
+      res.set('Content-Type', 'text/html');
+      res.send(Buffer.from(`<html>
+<head>
+  <title>Fragment Repost Form</title>
+</head>
+<body>
+  <script type="text/javascript">
+    function parseQuery(queryString) {
+      var query = {};
+      var pairs = (queryString[0] === '?' ? queryString.substr(1) : queryString).split('&');
+      for (var i = 0; i < pairs.length; i++) {
+          var pair = pairs[i].split('=');
+          query[decodeURIComponent(pair[0])] = decodeURIComponent(pair[1] || '');
+      }
+      return query;
+    }
+
+    var fields = parseQuery(window.location.hash.substring(1));
+
+    var form = document.createElement('form');
+    form.method = 'POST';
+    Object.keys(fields).forEach((key) => {
+      if (key) { // empty fragment will yield {"":""};
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = key;
+        input.value = fields[key];
+        form.appendChild(input);
+      }
+    });
+    document.body.appendChild(form);
+    form.submit();
+  </script>
+</body>
+</html>`));
+    });
+  }
+
   return router;
 };
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,21 +108,6 @@
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
       "dev": true
     },
-    "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-      "dev": true
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -212,7 +197,7 @@
     },
     "callsites": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
       "dev": true
     },
@@ -393,20 +378,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "del": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-      "dev": true,
-      "requires": {
-        "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
-      }
-    },
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
@@ -474,9 +445,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.8.0.tgz",
-      "integrity": "sha512-Zok6Bru3y2JprqTNm14mgQ15YQu/SMDkWdnmHfFg770DIUlmMFd/gqqzCHekxzjHZJxXv3tmTpH0C1icaYJsRQ==",
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.9.0.tgz",
+      "integrity": "sha512-g4KWpPdqN0nth+goDNICNXGfJF7nNnepthp46CAlJoJtC5K/cLu3NgCM3AHu1CkJ5Hzt9V0Y0PBAO6Ay/gGb+w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -724,14 +695,14 @@
       }
     },
     "flat-cache": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.2.tgz",
-      "integrity": "sha512-KByBY8c98sLUAGpnmjEdWTrtrLZRtZdwds+kAL/ciFXTCb7AZgqKsAnVnYFQj1hxepwO8JKN/8AsRWwLq+RK0A==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+      "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
       "dev": true,
       "requires": {
         "circular-json": "^0.3.1",
-        "del": "^3.0.0",
         "graceful-fs": "^4.1.2",
+        "rimraf": "~2.6.2",
         "write": "^0.2.1"
       }
     },
@@ -794,31 +765,10 @@
       }
     },
     "globals": {
-      "version": "11.8.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.8.0.tgz",
-      "integrity": "sha512-io6LkyPVuzCHBSQV9fmOwxZkUk6nIaGmxheLDgmuFv89j0fm2aqDbIXKAGfzCMHqz3HLF2Zf8WSG6VqMh2qFmA==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+      "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
       "dev": true
-    },
-    "globby": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
-      "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
-      "dev": true,
-      "requires": {
-        "array-union": "^1.0.1",
-        "glob": "^7.0.3",
-        "object-assign": "^4.0.1",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        }
-      }
     },
     "got": {
       "version": "8.3.2",
@@ -985,30 +935,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
       "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA="
-    },
-    "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-      "dev": true
-    },
-    "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
-      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "^1.0.1"
-      }
     },
     "is-plain-obj": {
       "version": "1.1.0",
@@ -1445,12 +1371,6 @@
       "resolved": "http://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
       "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4="
     },
-    "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-      "dev": true
-    },
     "p-some": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/p-some/-/p-some-2.0.1.tgz",
@@ -1507,21 +1427,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "^2.0.0"
-      }
     },
     "pluralize": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.2.0",
-    "eslint": "^5.8.0",
+    "eslint": "^5.9.0",
     "express": "^4.16.4",
     "mocha": "^5.2.0"
   },

--- a/test/routes.tests.js
+++ b/test/routes.tests.js
@@ -3,46 +3,200 @@ const url = require('url');
 const expressOpenid = require('./..');
 
 describe('routes', function() {
-  const router = expressOpenid.routes({
-    client_id: '123',
-    base_url: 'https://myapp.com',
-    issuer_base_url: 'https://flosser.auth0.com'
-  });
-
-  it('should contains two routes', function() {
-    assert.equal(router.stack.length, 2);
-  });
-
-  it('should contains a login route', function() {
-    const route = router.stack[0].route;
-    assert.equal(route.path, '/login');
-    assert.deepEqual(route.methods, { get: true });
-  });
-
-  it('should redirect to the authorize url properly on /login', async function() {
-    const route = router.stack[0].route;
-    const handle = route.stack[0].handle;
-    let redirectUrl;
-    await handle({
-      session: {},
-    }, {
-      redirect: rurl => redirectUrl = rurl
+  describe('default', () => {
+    const router = expressOpenid.routes({
+      client_id: '123',
+      base_url: 'https://myapp.com',
+      issuer_base_url: 'https://flosser.auth0.com'
     });
-    const parsed = url.parse(redirectUrl, true);
-    assert.equal(parsed.hostname, 'flosser.auth0.com');
-    assert.equal(parsed.pathname, '/authorize');
-    assert.equal(parsed.query.client_id, '123');
-    assert.equal(parsed.query.scope, 'openid profile email');
-    assert.equal(parsed.query.response_type, 'id_token');
-    assert.equal(parsed.query.response_mode, 'form_post');
-    assert.equal(parsed.query.redirect_uri, 'https://myapp.com/callback');
-    assert.property(parsed.query, 'nonce');
-    assert.property(parsed.query, 'state');
+
+    it('should contain two routes', function() {
+      assert.equal(router.stack.length, 2);
+    });
+
+    it('should contain a login route', function() {
+      const route = router.stack[0].route;
+      assert.equal(route.path, '/login');
+      assert.deepEqual(route.methods, { get: true });
+    });
+
+    it('should redirect to the authorize url properly on /login', async function() {
+      const route = router.stack[0].route;
+      const handle = route.stack[0].handle;
+      let redirectUrl;
+      await handle({
+        session: {},
+      }, {
+        redirect: rurl => redirectUrl = rurl
+      });
+      const parsed = url.parse(redirectUrl, true);
+      assert.equal(parsed.hostname, 'flosser.auth0.com');
+      assert.equal(parsed.pathname, '/authorize');
+      assert.equal(parsed.query.client_id, '123');
+      assert.equal(parsed.query.scope, 'openid profile email');
+      assert.equal(parsed.query.response_type, 'id_token');
+      assert.equal(parsed.query.response_mode, 'form_post');
+      assert.equal(parsed.query.redirect_uri, 'https://myapp.com/callback');
+      assert.property(parsed.query, 'nonce');
+      assert.property(parsed.query, 'state');
+    });
+
+    it('should contain a POST callback route', function() {
+      const route = router.stack[1].route;
+      assert.equal(route.path, '/callback');
+      assert.deepEqual(route.methods, { post: true });
+    });
   });
 
-  it('should contains a callback route', function() {
-    const route = router.stack[1].route;
-    assert.equal(route.path, '/callback');
-    assert.deepEqual(route.methods, { post: true });
+  describe('implied response_mode', () => {
+    describe('response_type=none', () => {
+      const router = expressOpenid.routes({
+        client_id: '123',
+        base_url: 'https://myapp.com',
+        issuer_base_url: 'https://flosser.auth0.com',
+        authorizationParams: {
+          response_mode: undefined,
+          response_type: 'none',
+        }
+      });
+
+      it('should contain two routes', function() {
+        assert.equal(router.stack.length, 2);
+      });
+
+      it('should contain a login route', function() {
+        const route = router.stack[0].route;
+        assert.equal(route.path, '/login');
+        assert.deepEqual(route.methods, { get: true });
+      });
+
+      it('should redirect to the authorize url properly on /login', async function() {
+        const route = router.stack[0].route;
+        const handle = route.stack[0].handle;
+        let redirectUrl;
+        await handle({
+          session: {},
+        }, {
+          redirect: rurl => redirectUrl = rurl
+        });
+        const parsed = url.parse(redirectUrl, true);
+        assert.equal(parsed.hostname, 'flosser.auth0.com');
+        assert.equal(parsed.pathname, '/authorize');
+        assert.equal(parsed.query.client_id, '123');
+        assert.equal(parsed.query.scope, 'openid profile email');
+        assert.equal(parsed.query.response_type, 'none');
+        assert.equal(parsed.query.response_mode, undefined);
+        assert.equal(parsed.query.redirect_uri, 'https://myapp.com/callback');
+        assert.property(parsed.query, 'nonce');
+        assert.property(parsed.query, 'state');
+      });
+
+      it('should contain a GET callback route', function() {
+        const route = router.stack[1].route;
+        assert.equal(route.path, '/callback');
+        assert.deepEqual(route.methods, { get: true });
+      });
+    });
+
+    describe('response_type=code', () => {
+      const router = expressOpenid.routes({
+        client_id: '123',
+        base_url: 'https://myapp.com',
+        issuer_base_url: 'https://flosser.auth0.com',
+        authorizationParams: {
+          response_mode: undefined,
+          response_type: 'code',
+        }
+      });
+
+      it('should contain two routes', function() {
+        assert.equal(router.stack.length, 2);
+      });
+
+      it('should contain a login route', function() {
+        const route = router.stack[0].route;
+        assert.equal(route.path, '/login');
+        assert.deepEqual(route.methods, { get: true });
+      });
+
+      it('should redirect to the authorize url properly on /login', async function() {
+        const route = router.stack[0].route;
+        const handle = route.stack[0].handle;
+        let redirectUrl;
+        await handle({
+          session: {},
+        }, {
+          redirect: rurl => redirectUrl = rurl
+        });
+        const parsed = url.parse(redirectUrl, true);
+        assert.equal(parsed.hostname, 'flosser.auth0.com');
+        assert.equal(parsed.pathname, '/authorize');
+        assert.equal(parsed.query.client_id, '123');
+        assert.equal(parsed.query.scope, 'openid profile email');
+        assert.equal(parsed.query.response_type, 'code');
+        assert.equal(parsed.query.response_mode, undefined);
+        assert.equal(parsed.query.redirect_uri, 'https://myapp.com/callback');
+        assert.property(parsed.query, 'nonce');
+        assert.property(parsed.query, 'state');
+      });
+
+      it('should contain a GET callback route', function() {
+        const route = router.stack[1].route;
+        assert.equal(route.path, '/callback');
+        assert.deepEqual(route.methods, { get: true });
+      });
+    });
+
+    describe('response_type=id_token', () => {
+      const router = expressOpenid.routes({
+        client_id: '123',
+        base_url: 'https://myapp.com',
+        issuer_base_url: 'https://flosser.auth0.com',
+        authorizationParams: {
+          response_mode: undefined,
+          response_type: 'id_token',
+        }
+      });
+
+      it('should contain two routes', function() {
+        assert.equal(router.stack.length, 3);
+      });
+
+      it('should contain a login route', function() {
+        const route = router.stack[0].route;
+        assert.equal(route.path, '/login');
+        assert.deepEqual(route.methods, { get: true });
+      });
+
+      it('should redirect to the authorize url properly on /login', async function() {
+        const route = router.stack[0].route;
+        const handle = route.stack[0].handle;
+        let redirectUrl;
+        await handle({
+          session: {},
+        }, {
+          redirect: rurl => redirectUrl = rurl
+        });
+        const parsed = url.parse(redirectUrl, true);
+        assert.equal(parsed.hostname, 'flosser.auth0.com');
+        assert.equal(parsed.pathname, '/authorize');
+        assert.equal(parsed.query.client_id, '123');
+        assert.equal(parsed.query.scope, 'openid profile email');
+        assert.equal(parsed.query.response_type, 'id_token');
+        assert.equal(parsed.query.response_mode, undefined);
+        assert.equal(parsed.query.redirect_uri, 'https://myapp.com/callback');
+        assert.property(parsed.query, 'nonce');
+        assert.property(parsed.query, 'state');
+      });
+
+      it('should contain a GET (repost) and POST callback route', function() {
+        let route = router.stack[1].route;
+        assert.equal(route.path, '/callback');
+        assert.deepEqual(route.methods, { post: true });
+        route = router.stack[2].route;
+        assert.equal(route.path, '/callback');
+        assert.deepEqual(route.methods, { get: true });
+      });
+    });
   });
 });


### PR DESCRIPTION
this PR adds additional (third) route in cases when `response_mode` is either explicitly set to `fragment` or implied to be the one defaulted to by AS from the used `response_type`.