### PR TITLE
export an enum with response modes and add an extra validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 const cb = require('cb');
 const fs = require('fs');
 const paramsValidator = require('./lib/paramsValidator');
+const ResponseMode = require('./lib/ResponseMode');
 
 const getRepostView = _.memoize(() => fs.readFileSync(__dirname + '/views/repost.html'));
 
@@ -43,7 +44,7 @@ module.exports.protect = function() {
 */
 module.exports.routes = function(params) {
   params = paramsValidator.validate(params);
-  const authorizeParams = params.authorizeParams;
+  const authorizeParams = params.authorizationParams;
 
   if (typeof express.Router === 'undefined') {
     throw new Error(`express-openid-client needs express@^3, current installed version ${require('express/package').version}`);
@@ -135,3 +136,6 @@ module.exports.routes = function(params) {
 
   return router;
 };
+
+
+module.exports.ResponseMode = ResponseMode;

--- a/lib/ResponseMode.js
+++ b/lib/ResponseMode.js
@@ -1,0 +1,37 @@
+/**
+ *
+ * Specifies the mode of the response according to
+ * [OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html) and
+ * [OAuth 2.0 Form Post Response Mode](https://openid.net/specs/oauth-v2-form-post-response-mode-1_0.html).
+ *
+ * @enum {string}
+ *
+*/
+module.exports = {
+
+  /**
+  * Uses the default mode for the response_type
+  * as stated in [OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html)
+  */
+  Default: undefined,
+
+  /**
+  * Authorization Response parameters are encoded in
+  * the query string added to the redirect_uri when redirecting back to the Client.
+  */
+  Query: 'query',
+
+  /**
+  * Authorization Response parameters are encoded in
+  * the fragment added to the redirect_uri when redirecting back to the Client.
+  */
+  Fragment: 'fragment',
+
+  /**
+  * Authorization Response parameters are encoded as HTML form values
+  * that are auto-submitted in the User Agent, and thus are transmitted via the HTTP POST method
+  * to the Client, with the result parameters being encoded in the body using the application/x-www-form-urlencoded format.
+  * The action attribute of the form is the Client's Redirection URI and the method of the form attribute is POST.
+  */
+  FormPost: 'form_post'
+};

--- a/lib/client.js
+++ b/lib/client.js
@@ -2,7 +2,7 @@ const { Issuer } = require('openid-client');
 const _ = require('lodash');
 
 async function get(params) {
-  const authorizeParams = params.authorizeParams;
+  const authorizeParams = params.authorizationParams;
 
   const issuer = await Issuer.discover(params.issuer_base_url);
 

--- a/lib/paramsValidator.js
+++ b/lib/paramsValidator.js
@@ -2,6 +2,7 @@ const Joi = require('joi');
 const deprecate = require('deprecate');
 const _ = require('lodash');
 const loadEnvs = require('./loadEnvs');
+const ResponseMode = require('./ResponseMode');
 
 const defaultAuthorizeParams = {
   response_type: 'id_token',
@@ -11,7 +12,7 @@ const defaultAuthorizeParams = {
 
 const authorizationParamsSchema = Joi.object().keys({
   response_type: Joi.string().required().default('id_token'),
-  response_mode: Joi.string().default('form_post'),
+  response_mode: [Joi.string().optional(), Joi.allow(null).optional()],
   scope: Joi.string().required().default('openid profile email')
 });
 
@@ -25,7 +26,7 @@ const paramsSchema = Joi.object().keys({
   authorizationParams: Joi.object().optional()
 });
 
-function buildAutorizeParams(params) {
+function buildAuthorizeParams(params) {
   const authorizationParams = Object.assign({}, defaultAuthorizeParams, params.authorizationParams || {});
   const authParamsValidation = Joi.validate(authorizationParams, authorizationParamsSchema);
   if(authParamsValidation.error) {
@@ -57,7 +58,14 @@ module.exports.validate = function(params) {
     throw new Error(paramsValidation.error.details[0].message);
   }
 
-  params.authorizeParams = buildAutorizeParams(params);
+  params.authorizationParams = buildAuthorizeParams(params);
+
+  const missingClientSecret = !params.client_secret &&
+    params.authorizationParams.response_type.split(' ').includes('code');
+
+  if(missingClientSecret) {
+    throw new Error('"client_secret" is required for response_type code and response_mode query');
+  }
 
   return params;
 };

--- a/test/invalid_params.tests.js
+++ b/test/invalid_params.tests.js
@@ -1,6 +1,6 @@
 const { assert } = require('chai');
 const expressOpenid = require('..');
-
+const ResponseMode = expressOpenid.ResponseMode;
 
 describe('invalid parameters', function() {
   it('should fail when the issuer_base_url is invalid', function() {
@@ -39,5 +39,18 @@ describe('invalid parameters', function() {
         client_id: 'asdas'
       });
     }, '"base_url" is required');
+  });
+
+  it('should fail when client secret is not provided and using the response type code in mode query', function() {
+    assert.throws(() => {
+      expressOpenid.routes({
+        issuer_base_url: 'http://foobar.auth0.com',
+        base_url: 'http://foobar.com',
+        client_id: 'asdas',
+        authorizationParams: {
+          response_type: 'code id_token'
+        }
+      });
+    }, '"client_secret" is required for response_type code');
   });
 });

--- a/test/routes.tests.js
+++ b/test/routes.tests.js
@@ -100,6 +100,7 @@ describe('routes', function() {
     describe('response_type=code', () => {
       const router = expressOpenid.routes({
         client_id: '123',
+        client_secret: '456',
         base_url: 'https://myapp.com',
         issuer_base_url: 'https://flosser.auth0.com',
         authorizationParams: {


### PR DESCRIPTION
Export a new enum for the valid response modes I documented this using the specs:
http://take.ms/6rccC

Validate that the user is supplying a `client_secret` either by using a params or environment variable when the response_type includes `code`.